### PR TITLE
Adding support for optional MB payment max date

### DIFF
--- a/src/Gordalina/Easypay/Config.php
+++ b/src/Gordalina/Easypay/Config.php
@@ -45,6 +45,12 @@ class Config
     protected $code;
 
     /**
+     * Optional maxdate for MB payments.
+     * @var string
+     */
+    protected $maxdate;
+
+    /**
      * @param string $user
      * @param string $entity
      * @param string $cin
@@ -52,7 +58,7 @@ class Config
      * @param string $language
      * @param string $code
      */
-    public function __construct($user, $entity, $cin, $country = 'PT', $language = 'PT', $code = NULL)
+    public function __construct($user, $entity, $cin, $country = 'PT', $language = 'PT', $code = NULL, $maxdate = NULL)
     {
         $this->user = $user;
         $this->entity = $entity;
@@ -62,6 +68,8 @@ class Config
         $this->language = $language;
 
         $this->code = $code;
+
+	$this->maxdate = $maxdate;
     }
 
     /**
@@ -110,5 +118,13 @@ class Config
     public function getCode()
     {
         return $this->code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMaxDate()
+    {
+        return $this->maxdate;
     }
 }

--- a/src/Gordalina/Easypay/Request/CreatePayment.php
+++ b/src/Gordalina/Easypay/Request/CreatePayment.php
@@ -70,7 +70,7 @@ class CreatePayment implements RequestInterface
             't_value' => strval($this->payment->getValue()),
             't_key' => $this->payment->getKey(),
         );
-
+	
         if ($this->payment->getCustomerInfo() instanceof CustomerInfo) {
             $parameters = array_merge($parameters, $this->payment->getCustomerInfo()->toArray());
         }
@@ -79,6 +79,12 @@ class CreatePayment implements RequestInterface
         if ($config->getCode()) {
             $parameters['s_code'] = $config->getCode();
         }
+
+	// Optional MB max date
+	if ($config->getMaxDate()){
+	    $parameters['o_max_date'] = $config->getMaxDate();
+            $parameters['ep_partner'] = $config->getUser();
+	}	
 
         switch ($this->payment->getType()) {
             case Payment::TYPE_BOLETO:


### PR DESCRIPTION
When a maxdate is set during the creation of a Payment Identifier, easypay will not accept payments by Multibanco after the date expires.
