### PR TITLE
Adding support for optional MB payment maximum date

### DIFF
--- a/src/Gordalina/Easypay/Config.php
+++ b/src/Gordalina/Easypay/Config.php
@@ -45,6 +45,12 @@ class Config
     protected $code;
 
     /**
+     * Optional maxdate for MB payments.
+     * @var string
+     */
+    protected $maxdate;
+
+    /**
      * @param string $user
      * @param string $entity
      * @param string $cin
@@ -52,7 +58,7 @@ class Config
      * @param string $language
      * @param string $code
      */
-    public function __construct($user, $entity, $cin, $country = 'PT', $language = 'PT', $code = NULL)
+    public function __construct($user, $entity, $cin, $country = 'PT', $language = 'PT', $code = NULL, $maxdate = NULL)
     {
         $this->user = $user;
         $this->entity = $entity;
@@ -62,6 +68,8 @@ class Config
         $this->language = $language;
 
         $this->code = $code;
+
+	$this->maxdate = $maxdate;
     }
 
     /**
@@ -110,5 +118,13 @@ class Config
     public function getCode()
     {
         return $this->code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMaxDate()
+    {
+        return $this->maxdate;
     }
 }

--- a/src/Gordalina/Easypay/Config.php
+++ b/src/Gordalina/Easypay/Config.php
@@ -45,12 +45,6 @@ class Config
     protected $code;
 
     /**
-     * Optional maxdate for MB payments.
-     * @var string
-     */
-    protected $maxdate;
-
-    /**
      * @param string $user
      * @param string $entity
      * @param string $cin
@@ -58,7 +52,7 @@ class Config
      * @param string $language
      * @param string $code
      */
-    public function __construct($user, $entity, $cin, $country = 'PT', $language = 'PT', $code = NULL, $maxdate = NULL)
+    public function __construct($user, $entity, $cin, $country = 'PT', $language = 'PT', $code = NULL)
     {
         $this->user = $user;
         $this->entity = $entity;
@@ -68,8 +62,6 @@ class Config
         $this->language = $language;
 
         $this->code = $code;
-
-	$this->maxdate = $maxdate;
     }
 
     /**
@@ -118,13 +110,5 @@ class Config
     public function getCode()
     {
         return $this->code;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMaxDate()
-    {
-        return $this->maxdate;
     }
 }

--- a/src/Gordalina/Easypay/Payment/Payment.php
+++ b/src/Gordalina/Easypay/Payment/Payment.php
@@ -16,6 +16,7 @@ class Payment
     const TYPE_NORMAL = 'normal';
     const TYPE_BOLETO = 'boleto';
     const TYPE_MOTO = 'moto';
+    const MAX_DATE_FORMAT = 'Y-m-d';
 
     /**
      * @var float
@@ -33,7 +34,7 @@ class Payment
     protected $type = self::TYPE_NORMAL;
 
     /**
-     * @var int
+     * @var string
      */
     protected $maxDate;
 
@@ -95,12 +96,16 @@ class Payment
         $this->type = $type;
     }
 
+    /**
+     * @param $maxDate
+     */
     public function setMaxDate($maxDate)
     {
-        $maxDate = (int) $maxDate;
+        $date = \DateTime::createFromFormat(static::MAX_DATE_FORMAT, $maxDate);
+        $isValid = $date && $date->format(static::MAX_DATE_FORMAT) == $maxDate;
 
-        if ($maxDate <= 0) {
-            throw new \InvalidArgumentException("Number of days must be greater than 0");
+        if (!$isValid) {
+            throw new \InvalidArgumentException('Maximum payment date must be in that format: '.static::MAX_DATE_FORMAT);
         }
 
         $this->maxDate = $maxDate;

--- a/src/Gordalina/Easypay/Payment/Payment.php
+++ b/src/Gordalina/Easypay/Payment/Payment.php
@@ -101,11 +101,11 @@ class Payment
      */
     public function setMaxDate($maxDate)
     {
-        $date = \DateTime::createFromFormat(static::MAX_DATE_FORMAT, $maxDate);
-        $isValid = $date && $date->format(static::MAX_DATE_FORMAT) == $maxDate;
+        $date = \DateTime::createFromFormat(self::MAX_DATE_FORMAT, $maxDate);
+        $isValid = $date && $date->format(self::MAX_DATE_FORMAT) == $maxDate;
 
         if (!$isValid) {
-            throw new \InvalidArgumentException('Maximum payment date must be in that format: '.static::MAX_DATE_FORMAT);
+            throw new \InvalidArgumentException('Maximum payment date must be in that format: '.self::MAX_DATE_FORMAT);
         }
 
         $this->maxDate = $maxDate;

--- a/src/Gordalina/Easypay/Payment/Payment.php
+++ b/src/Gordalina/Easypay/Payment/Payment.php
@@ -97,7 +97,9 @@ class Payment
     }
 
     /**
+     * This method will define a due date for the payment
      * @param $maxDate
+     * @throws \InvalidArgumentException If maxDate is not in the format defined in Payment::MAX_DATE_FORMAT
      */
     public function setMaxDate($maxDate)
     {

--- a/src/Gordalina/Easypay/Payment/Payment.php
+++ b/src/Gordalina/Easypay/Payment/Payment.php
@@ -33,6 +33,11 @@ class Payment
     protected $type = self::TYPE_NORMAL;
 
     /**
+     * @var int
+     */
+    protected $maxDate;
+
+    /**
      * @var CustomerInfo
      */
     protected $customerInfo;
@@ -90,6 +95,17 @@ class Payment
         $this->type = $type;
     }
 
+    public function setMaxDate($maxDate)
+    {
+        $maxDate = (int) $maxDate;
+
+        if ($maxDate <= 0) {
+            throw new \InvalidArgumentException("Number of days must be greater than 0");
+        }
+
+        $this->maxDate = $maxDate;
+    }
+
     /**
      * @param CustomerInfo $customerInfo
      */
@@ -123,6 +139,14 @@ class Payment
     }
 
     /**
+     * @return string
+     */
+    public function getMaxDate()
+    {
+        return $this->maxDate;
+    }
+
+    /**
      * @return CustomerInfo
      */
     public function getCustomerInfo()
@@ -143,4 +167,5 @@ class Payment
             static::TYPE_MOTO,
         );
     }
+
 }

--- a/src/Gordalina/Easypay/Request/CreatePayment.php
+++ b/src/Gordalina/Easypay/Request/CreatePayment.php
@@ -80,11 +80,11 @@ class CreatePayment implements RequestInterface
             $parameters['s_code'] = $config->getCode();
         }
 
-	// Optional MB max date
-	if ($config->getMaxDate()){
-	    $parameters['o_max_date'] = $config->getMaxDate();
+        // Optional MB max date
+        if ($this->payment->getMaxDate()){
+            $parameters['o_max_date'] = $this->payment->getMaxDate();
             $parameters['ep_partner'] = $config->getUser();
-	}	
+        }
 
         switch ($this->payment->getType()) {
             case Payment::TYPE_BOLETO:

--- a/src/Gordalina/Easypay/Request/CreatePayment.php
+++ b/src/Gordalina/Easypay/Request/CreatePayment.php
@@ -80,7 +80,7 @@ class CreatePayment implements RequestInterface
             $parameters['s_code'] = $config->getCode();
         }
 
-        // Optional MB max date
+        // Optional maximum date for payment acceptance
         if ($this->payment->getMaxDate()){
             $parameters['o_max_date'] = $this->payment->getMaxDate();
             $parameters['ep_partner'] = $config->getUser();

--- a/src/Gordalina/Easypay/Request/CreatePayment.php
+++ b/src/Gordalina/Easypay/Request/CreatePayment.php
@@ -70,7 +70,7 @@ class CreatePayment implements RequestInterface
             't_value' => strval($this->payment->getValue()),
             't_key' => $this->payment->getKey(),
         );
-
+	
         if ($this->payment->getCustomerInfo() instanceof CustomerInfo) {
             $parameters = array_merge($parameters, $this->payment->getCustomerInfo()->toArray());
         }
@@ -79,6 +79,12 @@ class CreatePayment implements RequestInterface
         if ($config->getCode()) {
             $parameters['s_code'] = $config->getCode();
         }
+
+	// Optional MB max date
+	if ($config->getMaxDate()){
+	    $parameters['o_max_date'] = $config->getMaxDate();
+            $parameters['ep_partner'] = $config->getUser();
+	}	
 
         switch ($this->payment->getType()) {
             case Payment::TYPE_BOLETO:

--- a/tests/Gordalina/Easypay/Tests/Payment/PaymentTest.php
+++ b/tests/Gordalina/Easypay/Tests/Payment/PaymentTest.php
@@ -21,6 +21,7 @@ class PaymentTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('normal', Payment::TYPE_NORMAL);
         $this->assertSame('boleto', Payment::TYPE_BOLETO);
         $this->assertSame('moto', Payment::TYPE_MOTO);
+        $this->assertSame('Y-m-d', Payment::MAX_DATE_FORMAT);
     }
 
     public function testDefaultType()
@@ -68,14 +69,6 @@ class PaymentTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(1.23, $payment->getValue());
     }
 
-    public function testMaxValueType()
-    {
-        $payment = new Payment();
-        $payment->setMaxDate("4");
-
-        $this->assertSame(4, $payment->getMaxDate());
-    }
-
     public function testGettersSetters()
     {
         $customerInfo = new CustomerInfo();
@@ -83,12 +76,12 @@ class PaymentTest extends \PHPUnit_Framework_TestCase
         $payment = new Payment();
         $payment->setValue(1.23);
         $payment->setKey('secret');
-        $payment->setMaxDate(3);
+        $payment->setMaxDate('2014-11-29');
         $payment->setCustomerInfo($customerInfo);
 
         $this->assertSame(1.23, $payment->getValue());
         $this->assertSame('secret', $payment->getKey());
-        $this->assertSame(3, $payment->getMaxDate());
+        $this->assertSame('2014-11-29', $payment->getMaxDate());
         $this->assertSame($customerInfo, $payment->getCustomerInfo());
     }
 
@@ -128,18 +121,37 @@ class PaymentTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException InvalidArgumentException
      */
-    public function testNegativeMaxDate()
+    public function testInvalidMaxDate()
     {
         $payment = new Payment();
-        $payment->setMaxDate(-1);
+        $payment->setMaxDate('10-02-2014');
     }
 
     /**
      * @expectedException InvalidArgumentException
      */
-    public function testZeroMaxDate()
+    public function testInvalidMaxDateDay()
     {
         $payment = new Payment();
-        $payment->setMaxDate(0);
+        $payment->setMaxDate('2014-02-31');
     }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidMaxDateMonth()
+    {
+        $payment = new Payment();
+        $payment->setMaxDate('2014-13-10');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidMaxDateYear()
+    {
+        $payment = new Payment();
+        $payment->setMaxDate('14-11-21');
+    }
+
 }

--- a/tests/Gordalina/Easypay/Tests/Payment/PaymentTest.php
+++ b/tests/Gordalina/Easypay/Tests/Payment/PaymentTest.php
@@ -68,6 +68,14 @@ class PaymentTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(1.23, $payment->getValue());
     }
 
+    public function testMaxValueType()
+    {
+        $payment = new Payment();
+        $payment->setMaxDate("4");
+
+        $this->assertSame(4, $payment->getMaxDate());
+    }
+
     public function testGettersSetters()
     {
         $customerInfo = new CustomerInfo();
@@ -75,10 +83,12 @@ class PaymentTest extends \PHPUnit_Framework_TestCase
         $payment = new Payment();
         $payment->setValue(1.23);
         $payment->setKey('secret');
+        $payment->setMaxDate(3);
         $payment->setCustomerInfo($customerInfo);
 
         $this->assertSame(1.23, $payment->getValue());
         $this->assertSame('secret', $payment->getKey());
+        $this->assertSame(3, $payment->getMaxDate());
         $this->assertSame($customerInfo, $payment->getCustomerInfo());
     }
 
@@ -113,5 +123,23 @@ class PaymentTest extends \PHPUnit_Framework_TestCase
         $payment->setValue(10);
 
         $this->assertTrue($payment->isValid());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testNegativeMaxDate()
+    {
+        $payment = new Payment();
+        $payment->setMaxDate(-1);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testZeroMaxDate()
+    {
+        $payment = new Payment();
+        $payment->setMaxDate(0);
     }
 }

--- a/tests/Gordalina/Easypay/Tests/Request/CreatePaymentTest.php
+++ b/tests/Gordalina/Easypay/Tests/Request/CreatePaymentTest.php
@@ -100,6 +100,30 @@ class CreatePaymentTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('key', $params['t_key']);
     }
 
+    public function testMaxDate()
+    {
+        $payment = new Payment();
+        $payment->setValue(10);
+        $payment->setKey('key');
+        $payment->setMaxDate(3);
+
+        $request = new CreatePayment($payment);
+        $params = $request->handleRequest($this->getConfig());
+
+        $this->assertTrue(is_array($params));
+        $this->assertCount(10, $params);
+        $this->assertSame('cin', $params['ep_cin']);
+        $this->assertSame('user', $params['ep_user']);
+        $this->assertSame('entity', $params['ep_entity']);
+        $this->assertSame('language', $params['ep_language']);
+        $this->assertSame('country', $params['ep_country']);
+        $this->assertSame('auto', $params['ep_ref_type']);
+        $this->assertSame('10', $params['t_value']);
+        $this->assertSame('key', $params['t_key']);
+        $this->assertSame(3, $params['o_max_date']);
+        $this->assertSame('user', $params['ep_partner']);
+    }
+
     public function testCustomerInfo()
     {
         $customerInfo = new CustomerInfo();

--- a/tests/Gordalina/Easypay/Tests/Request/CreatePaymentTest.php
+++ b/tests/Gordalina/Easypay/Tests/Request/CreatePaymentTest.php
@@ -105,7 +105,7 @@ class CreatePaymentTest extends \PHPUnit_Framework_TestCase
         $payment = new Payment();
         $payment->setValue(10);
         $payment->setKey('key');
-        $payment->setMaxDate(3);
+        $payment->setMaxDate('2014-11-21');
 
         $request = new CreatePayment($payment);
         $params = $request->handleRequest($this->getConfig());
@@ -120,7 +120,7 @@ class CreatePaymentTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('auto', $params['ep_ref_type']);
         $this->assertSame('10', $params['t_value']);
         $this->assertSame('key', $params['t_key']);
-        $this->assertSame(3, $params['o_max_date']);
+        $this->assertSame('2014-11-21', $params['o_max_date']);
         $this->assertSame('user', $params['ep_partner']);
     }
 


### PR DESCRIPTION
When a maxdate is set during the creation of a Payment Identifier, easypay will not accept payments after the date expiration. 
[Link to documentation](https://docs.easypay.pt/?api=requestPaymentIdentifier)
